### PR TITLE
Decrease minimum compat of `YAML` to `0.4.5`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,5 +15,5 @@ PropDictsFunctorsExt = "Functors"
 [compat]
 Functors = "0.3, 0.4, 0.5"
 JSON = "0.21"
-YAML = "0.4.12"
+YAML = "0.4.5"
 julia = "1.10"


### PR DESCRIPTION
The current version of `YAML.load_file` has existed since `0.4.5`, so no need to be this restrictive in the `[compat]` entry of `YAML` here.