### PR TITLE
Fix bug when reading JSON files in `readprops`

### DIFF
--- a/src/propdict.jl
+++ b/src/propdict.jl
@@ -224,7 +224,7 @@ export readprops
 function readprops(filename::AbstractString; subst_pathvar::Bool = true, subst_env::Bool = true, trim_null::Bool = true)
     abs_filename = abspath(filename)
     d = if endswith(abs_filename, ".json")
-        JSON.Parser.parsefile(abs_filename)
+        JSON.parsefile(abs_filename)
     elseif endswith(abs_filename, ".yaml")
         YAML.load_file(abs_filename)
     end


### PR DESCRIPTION
`JSON.Parser` was removed going from `0.21` to `1`.
However, `JSON.parsefile` should still work for both versions.