### PR TITLE
Qualify `Dict` as `Base.Dict`

### DIFF
--- a/src/propdict.jl
+++ b/src/propdict.jl
@@ -70,8 +70,8 @@ _dict(p::PropDict) = getfield(p, :_internal_dict)
 
 Base.parent(p::PropDict) = _dict(p)
 
-Dict(p::PropDict) = _dict(p)
-Dict{Union{Symbol,Int},Any}(p::PropDict) = _dict(p)
+Base.Dict(p::PropDict) = _dict(p)
+Base.Dict{Union{Symbol,Int},Any}(p::PropDict) = _dict(p)
 
 
 is_props_dict_compatible(d::AbstractDict) = false


### PR DESCRIPTION
I'm getting this `WARNING` on `julia-1.12`

<img width="890" height="145" alt="image" src="https://github.com/user-attachments/assets/8515d9cf-d76b-47e6-8a77-ad42916e5bec" />

Should be fixed by qualifying `Dict` explicitly as `Base.Dict`.

