### PR TITLE
Handle I/O via package extensions, support writing to YAML

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PropDicts"
 uuid = "4dc08600-4268-439e-8673-d706fafbb426"
-version = "0.2.12"
+version = "0.3.0"
 
 [weakdeps]
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"

--- a/Project.toml
+++ b/Project.toml
@@ -2,15 +2,15 @@ name = "PropDicts"
 uuid = "4dc08600-4268-439e-8673-d706fafbb426"
 version = "0.2.12"
 
-[deps]
+[weakdeps]
+Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
-[weakdeps]
-Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
-
 [extensions]
 PropDictsFunctorsExt = "Functors"
+PropDictsJSONExt = "JSON"
+PropDictsYAMLExt = "YAML"
 
 [compat]
 Functors = "0.3, 0.4, 0.5"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 PropDicts implements dictionaries that handle hierarchical property/value
 data, e.g. configuration data, with support for deep merging and
-variable substitution.
+variable substitution. Reading/writing from/to JSON and YAML is supported as well.
 
 * [Documentation for stable version](https://oschulz.github.io/PropDicts.jl/stable)
 * [Documentation for development version](https://oschulz.github.io/PropDicts.jl/dev)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,3 +11,5 @@ amend or remove specific parts of it.
 In addition, there is support for variable substitution, to make it possible
 to refer to environment variables and application-specific variables in
 configuration data.
+
+Reading/writing from/to JSON and YAML is supported as well.

--- a/ext/PropDictsJSONExt.jl
+++ b/ext/PropDictsJSONExt.jl
@@ -1,0 +1,19 @@
+# This file is a part of PropDicts.jl, licensed under the MIT License (MIT).
+
+module PropDictsJSONExt
+
+using PropDicts
+import JSON
+
+PropDicts._read_from(::Val{:JSON}, filename::String) = JSON.parsefile(filename)
+
+function PropDicts._write_to(::Val{:JSON}, io::IO, p::PropDict, multiline::Bool, indent::Int)
+    indent_value = indent < 0 ? 4 : indent
+    if multiline
+        JSON.print(io, p, indent_value)
+    else
+        JSON.print(io, p)
+    end
+end
+
+end # module PropDictsJSONExt

--- a/ext/PropDictsYAMLExt.jl
+++ b/ext/PropDictsYAMLExt.jl
@@ -1,0 +1,23 @@
+# This file is a part of PropDicts.jl, licensed under the MIT License (MIT).
+
+module PropDictsYAMLExt
+
+using PropDicts
+import YAML
+
+PropDicts._read_from(::Val{:YAML}, filename::String) = YAML.load_file(filename)
+
+function PropDicts._write_to(::Val{:YAML}, io::IO, p::PropDict, multiline::Bool, indent::Int)
+    indent_value = indent < 0 ? 2 : indent
+    if !multiline
+        throw(ArgumentError("YAML can only be written in multiple lines, `multiline = false` is not supported."))
+    end
+    if indent_value != 2
+        throw(ArgumentError("YAML is always indented by 2 spaces, `indent = $indent_value` is not supported."))
+    end
+
+    YAML.write(io, p)
+    return nothing
+end
+
+end # module PropDictsYAMLExt

--- a/src/PropDicts.jl
+++ b/src/PropDicts.jl
@@ -4,9 +4,6 @@ __precompile__(true)
 
 module PropDicts
 
-import JSON
-import YAML
-
 include("dictmerge.jl")
 include("varsubst.jl")
 include("propdict.jl")

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,4 +2,6 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ Test.@testset "Package PropDicts" begin
     include("test_aqua.jl")
     include("test_varsubst.jl")
     include("test_propdict.jl")
+    include("test_io.jl")
     include("test_docs.jl")
     isempty(Test.detect_ambiguities(PropDicts))
 end # testset

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -1,0 +1,162 @@
+# This file is a part of PropDicts.jl, licensed under the MIT License (MIT).
+
+using PropDicts
+using Test
+
+import JSON
+import YAML
+
+@testset "JSON and YAML I/O" begin
+    # Create a test PropDict
+    p = PropDict(
+        :name => "test",
+        :value => 42,
+        :nested => PropDict(
+            :a => 1,
+            :b => "hello"
+        ),
+        :list => [1, 2, 3]
+    )
+
+    @testset "JSON I/O" begin
+        # Test writing to IO
+        io = IOBuffer()
+        writeprops(io, p; format = :JSON)
+        json_str = String(take!(io))
+        @test !isempty(json_str)
+        @test occursin("\"name\"", json_str)
+        @test occursin("\"test\"", json_str)
+
+        # Test writing with multiline=false
+        io = IOBuffer()
+        writeprops(io, p; format = :JSON, multiline = false)
+        json_str_compact = String(take!(io))
+        @test length(json_str_compact) < length(json_str)
+
+        # Test writing and reading from file
+        mktempdir() do tmpdir
+            jsonfile = joinpath(tmpdir, "test.json")
+            writeprops(jsonfile, p)
+            @test isfile(jsonfile)
+
+            # Read back
+            p_read = readprops(jsonfile)
+            @test p_read isa PropDict
+            @test p_read[:name] == "test"
+            @test p_read[:value] == 42
+            @test p_read[:nested][:a] == 1
+            @test p_read[:nested][:b] == "hello"
+        end
+
+        # Test variable substitution in JSON
+        mktempdir() do tmpdir
+            jsonfile = joinpath(tmpdir, "test_subst.json")
+            open(jsonfile, "w") do io
+                write(io, """{"path": "\$_/data", "home": "\$HOME"}""")
+            end
+
+            p_subst = readprops(jsonfile; subst_pathvar = true, subst_env = true)
+            @test normpath(p_subst[:path]) == normpath(joinpath(tmpdir, "data"))
+            @test p_subst[:home] == ENV["HOME"]
+        end
+    end
+
+    @testset "YAML I/O" begin
+        # Test writing to IO
+        io = IOBuffer()
+        writeprops(io, p; format = :YAML)
+        yaml_str = String(take!(io))
+        @test !isempty(yaml_str)
+        @test occursin("name:", yaml_str)
+        @test occursin("test", yaml_str)
+
+        # Test that multiline=false throws
+        io = IOBuffer()
+        @test_throws ArgumentError writeprops(io, p; format = :YAML, multiline = false)
+
+        # Test that non-default indent throws
+        io = IOBuffer()
+        @test_throws ArgumentError writeprops(io, p; format = :YAML, indent = 4)
+
+        # Test writing and reading from file
+        mktempdir() do tmpdir
+            yamlfile = joinpath(tmpdir, "test.yaml")
+            writeprops(yamlfile, p)
+            @test isfile(yamlfile)
+
+            # Read back
+            p_read = readprops(yamlfile)
+            @test p_read isa PropDict
+            @test p_read[:name] == "test"
+            @test p_read[:value] == 42
+            @test p_read[:nested][:a] == 1
+            @test p_read[:nested][:b] == "hello"
+
+            # Test .yml extension
+            ymlfile = joinpath(tmpdir, "test.yml")
+            writeprops(ymlfile, p)
+            @test isfile(ymlfile)
+            p_read_yml = readprops(ymlfile)
+            @test p_read_yml[:name] == "test"
+        end
+
+        # Test variable substitution in YAML
+        mktempdir() do tmpdir
+            yamlfile = joinpath(tmpdir, "test_subst.yaml")
+            open(yamlfile, "w") do io
+                write(io, "path: \"\$_/data\"\nhome: \"\$HOME\"\n")
+            end
+
+            p_subst = readprops(yamlfile; subst_pathvar = true, subst_env = true)
+            @test normpath(p_subst[:path]) == normpath(joinpath(tmpdir, "data"))
+            @test p_subst[:home] == ENV["HOME"]
+        end
+    end
+
+    @testset "Multiple file merge" begin
+        mktempdir() do tmpdir
+            file1 = joinpath(tmpdir, "base.json")
+            file2 = joinpath(tmpdir, "override.json")
+
+            open(file1, "w") do io
+                write(io, """{"a": 1, "b": {"c": 2, "d": 3}}""")
+            end
+            open(file2, "w") do io
+                write(io, """{"a": 10, "b": {"c": 20}}""")
+            end
+
+            p_merged = readprops([file1, file2])
+            @test p_merged[:a] == 10
+            @test p_merged[:b][:c] == 20
+            @test p_merged[:b][:d] == 3
+        end
+    end
+
+    @testset "Unsupported format" begin
+        mktempdir() do tmpdir
+            txtfile = joinpath(tmpdir, "test.txt")
+            touch(txtfile)
+            @test_throws ArgumentError readprops(txtfile)
+        end
+    end
+
+    @testset "trim_null in readprops" begin
+        mktempdir() do tmpdir
+            jsonfile = joinpath(tmpdir, "test_null.json")
+            open(jsonfile, "w") do io
+                write(io, """{"a": 1, "b": null, "c": {"d": null, "e": 2}}""")
+            end
+
+            # With trim_null (default)
+            p_trimmed = readprops(jsonfile)
+            @test !haskey(p_trimmed, :b)
+            @test !haskey(p_trimmed[:c], :d)
+            @test p_trimmed[:c][:e] == 2
+
+            # Without trim_null
+            p_with_null = readprops(jsonfile; trim_null = false)
+            @test haskey(p_with_null, :b)
+            @test p_with_null[:b] === nothing
+        end
+    end
+end


### PR DESCRIPTION
Breaking changes:

* The JSON or YAML package needs to be loaded now for I/O to work.
* JSON output use multiline by default now.
